### PR TITLE
Added "Dark-Mode" theme to css with toggle switch (html and jquery)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .rsync.sh
+.DS_Store

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+<meta charset ="UTF-8" name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
 <title>CFPB trend data downloader</title>
 
 <link rel="stylesheet" href="styles/style.css">
@@ -20,12 +20,34 @@ crossorigin="anonymous"></script>
 
 <div id="intro" class="primary">
 <!--jquery Dark Mode Button, needs localStorage to hold class when submitting API requests/reloading page-->
+<script>
+$(document).ready(function(){
+ if (localStorage.getItem('theme') == 'dark'){
+  $("body").addClass("dark-mode");
+  console.log("dark-theme")
+ } else {
+  $("body").removeClass("dark-mode");
+  localStorage.setItem('theme', 'light');
+  console.log("light-theme");
+ }
+});
+
+</script>
+
 
   <button id="darkToggle">Toggle dark mode</button>
 
   <script>
       $("#darkToggle").click(function(){
-        $("body").toggleClass("dark-mode");
+        if (localStorage.getItem('theme') == 'dark'){
+        $("body").removeClass("dark-mode");
+        localStorage.setItem('theme', 'light');
+        console.log("light-theme");
+        } else if (localStorage.getItem('theme') == 'undefined' || localStorage.getItem('theme') == 'light'){
+        $("body").addClass("dark-mode");
+        localStorage.setItem('theme', 'dark');
+        console.log("dark-theme");
+        } 
       });
   </script>
 

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
 src="https://code.jquery.com/jquery-3.5.1.min.js"
 integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
 crossorigin="anonymous"></script>
+<script type="text/javascript" src="scripts/dark_toggle.js"></script>
+
 </head>
 
 <body>
@@ -21,34 +23,17 @@ crossorigin="anonymous"></script>
 <div id="intro" class="primary">
 <!--jquery Dark Mode Button, needs localStorage to hold class when submitting API requests/reloading page-->
 <script>
-$(document).ready(function(){
- if (localStorage.getItem('theme') == 'dark'){
-  $("body").addClass("dark-mode");
-  console.log("dark-theme")
- } else {
-  $("body").removeClass("dark-mode");
-  localStorage.setItem('theme', 'light');
-  console.log("light-theme");
- }
+  $(document).ready(function(){
+    checkTheme();
 });
-
 </script>
-
 
   <button id="darkToggle">Toggle dark mode</button>
 
   <script>
-      $("#darkToggle").click(function(){
-        if (localStorage.getItem('theme') == 'dark'){
-        $("body").removeClass("dark-mode");
-        localStorage.setItem('theme', 'light');
-        console.log("light-theme");
-        } else if (localStorage.getItem('theme') == 'undefined' || localStorage.getItem('theme') == 'light'){
-        $("body").addClass("dark-mode");
-        localStorage.setItem('theme', 'dark');
-        console.log("dark-theme");
-        } 
-      });
+  $("#darkToggle").click(function(){
+    switchTheme();
+  });
   </script>
 
 <h1>CFPB trend data downloader</h1>

--- a/index.html
+++ b/index.html
@@ -9,12 +9,26 @@
 <link rel="icon" 
       type="image/ico" 
       href="https://gideonweissman.com/favicon.ico">
-
+<!--jquery CDN-->
+<script
+src="https://code.jquery.com/jquery-3.5.1.min.js"
+integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
+crossorigin="anonymous"></script>
 </head>
 
 <body>
 
 <div id="intro" class="primary">
+<!--jquery Dark Mode Button, needs localStorage to hold class when submitting API requests/reloading page-->
+
+  <button id="darkToggle">Toggle dark mode</button>
+
+  <script>
+      $("#darkToggle").click(function(){
+        $("body").toggleClass("dark-mode");
+      });
+  </script>
+
 <h1>CFPB trend data downloader</h1>
 
 <p>This is a tool for downloading complaint trend data from the Consumer Financial Protection Bureau (CFPB). The site requests data using the <a href="https://cfpb.github.io/api/ccdb/index.html" target='_blank'>CFPB's API</a>, and then makes that data available as a table and CSV for download.</p>

--- a/scripts/dark_toggle.js
+++ b/scripts/dark_toggle.js
@@ -1,0 +1,30 @@
+// checks localStorage and activates previous theme
+function checkTheme(){
+    if (localStorage.getItem('theme') == 'dark'){
+        darkTheme();
+    } else {
+        lightTheme();
+    }
+}   
+
+// checks localStorage and switches themes
+function switchTheme(){
+    if (localStorage.getItem('theme') == 'dark'){
+        lightTheme();
+      } else if (localStorage.getItem('theme') == 'undefined' || localStorage.getItem('theme') == 'light'){
+        darkTheme();
+      } 
+}
+
+// remove dark theme css class
+function lightTheme(){
+    $("body").removeClass("dark-mode");
+    localStorage.setItem('theme', 'light');
+    console.log("light-theme");
+}
+// add dark theme css class
+function darkTheme(){
+    $("body").addClass("dark-mode");
+    localStorage.setItem('theme', 'dark');
+    console.log("dark-theme");
+}

--- a/styles/style.css
+++ b/styles/style.css
@@ -1,6 +1,22 @@
 body {
     font-family: Helvetica, sans-serif;
+    background-color: whitesmoke;
+    color: black;
+    transition: 2s;
 }
+
+a:link{color:purple;}
+a:visited{color:blue;}
+a:hover{color:red;}
+a:active{color:orange;}
+
+.dark-mode {
+    background-color: black;
+    color: whitesmoke;
+}
+
+.dark-mode a:link{color:plum;}
+.dark-mode a:visited{color:lightskyblue;}
 
 select {
     max-width: 80%;
@@ -29,7 +45,6 @@ div.primary {
     margin-right: auto;
     margin-left: auto;
     padding: 15px;
-    background-color: white;
     max-width: 800px;
 }
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -2,7 +2,7 @@ body {
     font-family: Helvetica, sans-serif;
     background-color: whitesmoke;
     color: black;
-    transition: 2s;
+    /* transition: 2s; */
 }
 
 a:link{color:purple;}


### PR DESCRIPTION
Hey Gideon! I forked your repository and made a simple contribution to test it out... I added a ".dark-mode" css class and a button that toggles this class on/off to change the colors of the site.

I used localStorage to store the theme value, and jQuery's ".ready()" method to check this value when the DOM is ready... this ensures that the previously selected theme is stored in the browser even when the page reloads. This was necessary because submitting an API request reloads the page. I think it might be worth looking into modifying your script to use jQuery (ajax?) to load the API data into the page without a page refresh, but I'm not quite sure how that works. 

Check it out and let me know what you think! 